### PR TITLE
fix(rbac): permissions for creating and patching events

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,13 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - cert-manager.io
   resources:
   - certificaterequests

--- a/controllers/certificaterequest_controller.go
+++ b/controllers/certificaterequest_controller.go
@@ -45,6 +45,9 @@ type CertificateRequestReconciler struct {
 	KMSCA    *kmsca.KMSCA
 }
 
+// Annotation for generating RBAC role for writing Events
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests/status,verbs=get;update;patch
 

--- a/controllers/kmsissuer_controller.go
+++ b/controllers/kmsissuer_controller.go
@@ -45,6 +45,9 @@ type KMSIssuerReconciler struct {
 	KMSCA    *kmsca.KMSCA
 }
 
+// Annotation for generating RBAC role for writing Events
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
 // +kubebuilder:rbac:groups=cert-manager.skyscanner.net,resources=kmsissuers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.skyscanner.net,resources=kmsissuers/status,verbs=get;update;patch
 

--- a/controllers/kmskey_controller.go
+++ b/controllers/kmskey_controller.go
@@ -51,6 +51,9 @@ type KMSKeyReconciler struct {
 	KMSCA    *kmsca.KMSCA
 }
 
+// Annotation for generating RBAC role for writing Events
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
 // +kubebuilder:rbac:groups=cert-manager.skyscanner.net,resources=kmskeys,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.skyscanner.net,resources=kmskeys/status,verbs=get;update;patch
 

--- a/deploy/kubernetes/kms-issuer.yaml
+++ b/deploy/kubernetes/kms-issuer.yaml
@@ -261,6 +261,13 @@ metadata:
   name: kms-issuer-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - cert-manager.io
   resources:
   - certificaterequests


### PR DESCRIPTION
Adding missing permissions for `create` and `patch` `events` to `manager-role`