### PR TITLE
Signer.New will return Public Key errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 all: manager
 
 # Run tests
-test: generate tidy fmt vet manifests
+test: generate tidy fmt lint manifests
 ifeq ($(USE_EXISTING_CLUSTER), "true")
 	kind create cluster --name kms-issuer-test && \
 		USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) go test ./... -coverprofile cover.out

--- a/pkg/signer/kmssigner_test.go
+++ b/pkg/signer/kmssigner_test.go
@@ -55,8 +55,9 @@ var _ = Context("Signer", func() {
 			Expect(err).To(BeNil())
 
 			By("creating a new KMSSigner")
-			signer := signer.New(client, *key.KeyMetadata.KeyId)
+			signer, err := signer.New(client, *key.KeyMetadata.KeyId)
 			Expect(signer).NotTo(BeNil())
+			Expect(err).To(BeNil())
 
 			By("extracting the public key")
 			pub := signer.Public()
@@ -78,4 +79,13 @@ var _ = Context("Signer", func() {
 		})
 	})
 
+	Describe("Given an invalid KMS key ID", func() {
+		It("should fail", func() {
+			client := mocks.New()
+			By("erroring out")
+			signer, err := signer.New(client, "invalid key ID")
+			Expect(signer).To(BeNil())
+			Expect(err).NotTo(BeNil())
+		})
+	})
 })


### PR DESCRIPTION
Addressing https://github.com/Skyscanner/kms-issuer/issues/9

`signer.New` will return errors and fail `KMSIssuer` creation on public key errors.

Used and tested to debug IAM permission issues.

E.g.:
`KMSIssuer` Object

```yaml
apiVersion: cert-manager.skyscanner.net/v1alpha1
kind: KMSIssuer
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"cert-manager.skyscanner.net/v1alpha1","kind":"KMSIssuer","metadata":{"annotations":{},"name":"kms-issuer-example2","namespace":"kms-issuer"},"spec":{"commonName":"My Root CA","duration":"87600h","keyId":"alias/kmskey-example2"}}
  creationTimestamp: "2020-08-07T10:36:05Z"
  generation: 1
  name: kms-issuer-example2
  namespace: kms-issuer
  resourceVersion: "66906908"
  selfLink: /apis/cert-manager.skyscanner.net/v1alpha1/namespaces/kms-issuer/kmsissuers/kms-issuer-example2
  uid: cc595e4b-d899-11ea-8fdd-0a429028750a
spec:
  commonName: My Root CA
  duration: 87600h
  keyId: alias/kmskey-example2
status:
  conditions:
  - lastTransitionTime: "2020-08-07T10:36:05Z"
    message: Failed to generate the Certificate Authority Certificate
    reason: Failed
    status: "False"
    type: Ready
```

Logs:

```
 2020-08-07T11:06:36.394Z    ERROR    controllers.kmsissuer_controller    Failed to generate the Certificate Authority Certificate    {"kms-issuer": "kms-issuer/kms-issuer-example2", "error": "AccessDeniedException: User: arn:aws:sts::xxx:assumed-role/xxxx/xxxx is not authorized to perform: kms:GetPublicKey on resource: arn:aws:kms:xxx:xxxx:key/xxx\n\tstatus code: 400, request id: 5f4a171f-e673-49c9-baad-9b7836627b9e"}
 github.com/go-logr/zapr.(*zapLogger).Error
     /go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128
 github.com/Skyscanner/kms-issuer/controllers.(*KMSIssuerReconciler).manageFailure
     /workspace/controllers/kmsissuer_controller.go:125
 github.com/Skyscanner/kms-issuer/controllers.(*KMSIssuerReconciler).Reconcile
     /workspace/controllers/kmsissuer_controller.go:94
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.1-0.20200416234307-5377effd4043/pkg/internal/controller/controller.go:256
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.1-0.20200416234307-5377effd4043/pkg/internal/controller/controller.go:232
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.1-0.20200416234307-5377effd4043/pkg/internal/controller/controller.go:211
 k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
     /go/pkg/mod/k8s.io/apimachinery@v0.18.1/pkg/util/wait/wait.go:155
 k8s.io/apimachinery/pkg/util/wait.BackoffUntil
     /go/pkg/mod/k8s.io/apimachinery@v0.18.1/pkg/util/wait/wait.go:156
 k8s.io/apimachinery/pkg/util/wait.JitterUntil
     /go/pkg/mod/k8s.io/apimachinery@v0.18.1/pkg/util/wait/wait.go:133
 k8s.io/apimachinery/pkg/util/wait.Until
     /go/pkg/mod/k8s.io/apimachinery@v0.18.1/pkg/util/wait/wait.go:90
```
