### PR TITLE
Fix flag description

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableApprovedCheck, "enable-approved-check", true,
-		"Disables waiting for CertificateRequests to have an approved condition before signing.")
+		"Enable waiting for CertificateRequests to have an approved condition before signing.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))


### PR DESCRIPTION
In [https://github.com/Skyscanner/kms-issuer/pull/18/](disable-approved-check) we switch the flag from `disable-approved-check` to `enable-approved-check` but forgot to update the flag description. 