### PR TITLE
image: skyscanner/kms-issuer:dev does not exist

### DIFF
--- a/deploy/kubernetes/kms-issuer.yaml
+++ b/deploy/kubernetes/kms-issuer.yaml
@@ -503,7 +503,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: skyscanner/kms-issuer:dev
+        image: ghcr.io/skyscanner/kms-issuer:sha-3ee48e5
         name: manager
         resources:
           limits:


### PR DESCRIPTION
image: skyscanner/kms-issuer:dev does not exist, changed to image ghcr.io/skyscanner/kms-issuer:sha-3ee48e5