### PR TITLE
Add e2e testing as a github workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,8 +34,6 @@ jobs:
         run: kubectl expose deployment local-kms -n local-kms --port 8080
       - name: Wait for local-kms pod to be ready
         run: kubectl wait --for=condition=Ready -l app=local-kms -n local-kms pod
-      - name: port-forward to local-kms
-        run: kubectl port-forward -n local-kms svc/local-kms 8080 &
 
       - name: Install cert-manager
         run: kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml
@@ -52,5 +50,8 @@ jobs:
         run: kubectl apply -f ./config/samples/cert-manager_v1alpha1_kmskey.yaml
       - name: Wait for key to be ready
         run: kubectl wait --for=condition=Ready kmskey/kmskey-sample
+
+      - name: port-forward to local-kms
+        run: kubectl port-forward -n local-kms svc/local-kms 8080 &
       - name: Test a KMSKey is created
         run: aws --endpoint http://localhost:8080 kms list-keys

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,6 +11,7 @@ jobs:
     env:
       IMG: skyscanner/kms-issuer:dev
     steps:
+      - uses: actions/checkout@v3.0.2
 
       # Build testing docker image
       - name: Build the testing kms-issuer docker image

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,5 +53,6 @@ jobs:
 
       - name: port-forward to local-kms
         run: kubectl port-forward -n local-kms svc/local-kms 8080 &
+        # See https://florian.ec/blog/github-actions-awscli-errors/
       - name: Test a KMSKey is created
-        run: aws --endpoint http://localhost:8080 kms list-keys
+        run: aws --endpoint http://localhost:8080 kms list-keys --region eu-west-1 --no-sign-request

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,25 +2,53 @@ name: E2E Tests
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   e2e:
     name: e2e
     runs-on: ubuntu-latest
+    env:
+      IMG: skyscanner/kms-issuer:dev
     steps:
-      - name: Testing with an echo
-        run: echo hi
+
+      # Build testing docker image
+      - name: Build the testing kms-issuer docker image
+        run: docker build -t ${IMG} .
+
+      # Setup kind cluster
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
-          node_image: kindest/node:v1.24.0
+          cluster_name: kind
+      - name: Load test docker image into the kind cluster
+        run: kind load docker-image ${IMG}
+
+      # Install local-kms to the cluster
       - name: Create local-kms namespace
         run: kubectl create namespace local-kms
       - name: Create local-kms deployment
         run: kubectl create deployment local-kms -n local-kms --port 8080 --image nsmithuk/local-kms:3.11.2
       - name: Create local-kms service
-        run: kubectl export deployment local-kms -n local-kms --port 8080
-      - name: Port Forward to local-kms service
-        run: kubectl port-forward svc/local-kms -n local-kms 8080:8080
-      - name: Test local-kms
+        run: kubectl expose deployment local-kms -n local-kms --port 8080
+      - name: Wait for local-kms pod to be ready
+        run: kubectl wait --for=condition=Ready -l app=local-kms -n local-kms pod
+      - name: port-forward to 
+
+      - name: Install cert-manager
+        run: kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml
+
+      - name: Install kms-issuer CRDs
+        run: make install
+
+      - name: Set docker image to use in Kustomization
+        run: cd config/manager && ./bin/kustomize/ edit set image controller=${IMG}
+      - name: Deploy kms-issuer
+        run: ./bin/kustomize/build config/testing | kubectl apply -f -
+
+      - name: Apply KMSKey from samples
+        run: kubectl apply -f ./config/samples/cert-manager_v1alpha1_kmskey.yaml
+      - name: Wait for key to be ready
+        run: kubectl wait --for=condition=Ready kmskey/kmskey-sample
+      - name: Test a KMSKey is created
         run: aws --endpoint http://localhost:8080 kms list-keys

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,26 @@
+name: E2E Tests
+
+on:
+  pull_request:
+
+jobs:
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Testing with an echo
+        run: echo hi
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          node_image: kindest/node:v1.24.0
+      - name: Create local-kms namespace
+        run: kubectl create namespace local-kms
+      - name: Create local-kms deployment
+        run: kubectl create deployment local-kms -n local-kms --port 8080 --image nsmithuk/local-kms:3.11.2
+      - name: Create local-kms service
+        run: kubectl export deployment local-kms -n local-kms --port 8080
+      - name: Port Forward to local-kms service
+        run: kubectl port-forward svc/local-kms -n local-kms 8080:8080
+      - name: Test local-kms
+        run: aws --endpoint http://localhost:8080 kms list-keys

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,7 +55,14 @@ jobs:
         run: kubectl port-forward -n local-kms svc/local-kms 8080 &
         # See https://florian.ec/blog/github-actions-awscli-errors/
       - name: Test a KMSKey is created
-        run: aws --endpoint http://localhost:8080 kms list-keys --region eu-west-1 --no-sign-request
+        run: |
+          result=$(aws --endpoint http://localhost:8080 kms list-keys --region eu-west-1 --no-sign-request | jq '(.Keys | length) == 1')
+          if [[ "${result}" == true ]]; then
+            echo -n "Key created"
+          else
+            echo -n "Key not found"
+            exit 1
+          fi
 
       - name: Apply KMSISsuer from sample
         run: kubectl apply -f ./config/samples/cert-manager_v1alpha1_kmsissuer.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,9 +44,9 @@ jobs:
         run: make install
 
       - name: Set docker image to use in Kustomization
-        run: cd config/manager && ./bin/kustomize/ edit set image controller=${IMG}
+        run: make kustomize && cd config/manager && kustomize edit set image controller=${IMG}
       - name: Deploy kms-issuer
-        run: ./bin/kustomize/build config/testing | kubectl apply -f -
+        run: kustomize build config/testing | kubectl apply -f -
 
       - name: Apply KMSKey from samples
         run: kubectl apply -f ./config/samples/cert-manager_v1alpha1_kmskey.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -56,3 +56,13 @@ jobs:
         # See https://florian.ec/blog/github-actions-awscli-errors/
       - name: Test a KMSKey is created
         run: aws --endpoint http://localhost:8080 kms list-keys --region eu-west-1 --no-sign-request
+
+      - name: Apply KMSISsuer from sample
+        run: kubectl apply -f ./config/samples/cert-manager_v1alpha1_kmsissuer.yaml
+      - name: Wait for KMSIssuer to be ready
+        run: kubectl wait --for=condition=Ready kmsissuer/kms-issuer-sample
+
+      - name: Apply Certificate from sample
+        run: kubectl apply -f ./config/samples/certificate.yaml
+      - name: Wait for Certificate to be ready  
+        run: kubectl wait --for=condition=Ready certificate.cert-manager.io/example-com

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,7 +33,8 @@ jobs:
         run: kubectl expose deployment local-kms -n local-kms --port 8080
       - name: Wait for local-kms pod to be ready
         run: kubectl wait --for=condition=Ready -l app=local-kms -n local-kms pod
-      - name: port-forward to 
+      - name: port-forward to local-kms
+        run: kubectl port-forward -n local-kms svc/local-kms 8080 &
 
       - name: Install cert-manager
         run: kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v4.5.5
+KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.8.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
+KUSTOMIZE_VERSION ?= v4.5.5
 CONTROLLER_TOOLS_VERSION ?= v0.8.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/config/samples/cert-manager.skyscanner.net_v1alpha1_kmsissuer.yaml
+++ b/config/samples/cert-manager.skyscanner.net_v1alpha1_kmsissuer.yaml
@@ -1,6 +1,0 @@
-apiVersion: cert-manager.skyscanner.net/v1alpha1
-kind: KMSIssuer
-metadata:
-  name: kmsissuer-sample
-spec:
-  # TODO(user): Add fields here

--- a/config/samples/cert-manager_v1alpha1_kmsissuer.yaml
+++ b/config/samples/cert-manager_v1alpha1_kmsissuer.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   commonName: Test Root CA
   duration: 87600h # 10 years
-  keyId: a9695e53-9355-4f6e-8b60-dec3b19912b3
+  keyId: alias/kms-issuer-example

--- a/config/samples/certificate.yaml
+++ b/config/samples/certificate.yaml
@@ -33,7 +33,7 @@ spec:
     - 192.168.0.5
   # Issuer references are always required.
   issuerRef:
-    name: kms-issuer
+    name: kms-issuer-sample
     # We can reference ClusterIssuers by changing the kind here.
     # The default value is Issuer (i.e. a locally namespaced Issuer)
     kind: KMSIssuer

--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -1,0 +1,12 @@
+# Kustomization used during testing which sets overrides for --local-aws-endpoint, etc.
+bases:
+- ../default
+
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/1/args/0
+      value: --local-aws-endpoint=http://local-kms.local-kms.svc.cluster.local:8080
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ import (
 	certmanagerskyscannernetv1alpha1 "github.com/Skyscanner/kms-issuer/api/v1alpha1"
 	"github.com/Skyscanner/kms-issuer/controllers"
 	"github.com/Skyscanner/kms-issuer/pkg/kmsca"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	//+kubebuilder:scaffold:imports
@@ -59,6 +61,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection, enableApprovedCheck bool
 	var probeAddr string
+	var localstack bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -66,6 +69,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableApprovedCheck, "enable-approved-check", true,
 		"Enable waiting for CertificateRequests to have an approved condition before signing.")
+	flag.BoolVar(&localstack, "localstack", false,
+		"Use localstack aws endpoints for local testing")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -88,9 +93,25 @@ func main() {
 	}
 
 	// Create a new aws session
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+	var sess *session.Session
+	if localstack {
+		// Testing mode
+		sess = session.Must(session.NewSessionWithOptions(session.Options{
+			Config: aws.Config{
+				Region:           aws.String("us-east-1"),
+				Credentials:      credentials.NewStaticCredentials("test", "test", ""),
+				S3ForcePathStyle: aws.Bool(true),
+				Endpoint:         aws.String("http://localhost:8082"),
+				// Endpoint:         aws.String("http://localstack.localstack.svc.cluster.local:4566"),
+			},
+			SharedConfigState: session.SharedConfigEnable,
+		}))
+	} else {
+		// Production mode
+		sess = session.Must(session.NewSessionWithOptions(session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		}))
+	}
 	ca := kmsca.NewKMSCA(sess)
 
 	if err = (controllers.NewKMSIssuerReconciler(mgr, ca)).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
# Summary

- allow a `--local-aws-endpoint` flag for testing
- use https://github.com/nsmithuk/local-kms as fake aws KMS endpoint
- create github-actions workflow with simple test of a `KMSKey`, `KMSIssuer`, and `Certificate`.
- ensure the KMS key is created
- ensure the certificate is signed using the KMSIssuer