### PR TITLE
Fix typo in README. All checks on push to main.

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,7 +1,11 @@
 name: CodeQL
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '20 17 * * 1'
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,9 @@
 name: E2E Tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,6 +1,9 @@
 name: Helm Chart Tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test-build:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://github.com/Skyscanner/kms-issuer/actions/workflows/test-build.yml/badge.svg?branch=main)](https://github.com/Skyscanner/kms-issuer/actions)
 [![CodeQL Status](https://github.com/Skyscanner/kms-issuer/actions/workflows/code-quality.yml/badge.svg?branch=main)](https://github.com/Skyscanner/kms-issuer/actions)
+[![E2E Tests](https://github.com/Skyscanner/kms-issuer/actions/workflows/e2e.yaml/badge.svg?branch=main)](https://github.com/Skyscanner/kms-issuer/actions)
+[![Helm Chart Tests](https://github.com/Skyscanner/kms-issuer/actions/workflows/helm.yml/badge.svg?branch=main)](https://github.com/Skyscanner/kms-issuer/actions)
 
 KMS issuer is a [cert-manager](https://cert-manager.io/) Certificate Request controller that uses [AWS KMS](https://aws.amazon.com/kms/) to sign the certificate request.
 
@@ -20,18 +22,11 @@ helm repo add kms-issuer 'https://skyscanner.github.io/kms-issuer'
 helm repo update
 ```
 
-To install the chart with the release name `kmsrelease`:
+To install the chart with the release name `kms-issuer`:
 
 ```console
-    # Create the infrabin namespace:
-
-    kubectl create namespace kms-issuer-system
-
-    Run helm install:
-
-    helm upgrade --install kmsrelease kms-issuer/kms-issuer \
-    --namespace kms-issuer-system
-```console
+helm upgrade --install kms-issuer kms-issuer/kms-issuer --namespace kms-issuer-system --create-namespace
+```
 
 ### Usage
 


### PR DESCRIPTION
# Summary

- add other badges to README
- change install command to include `--create-namespace`
- remove reference to infrabin
- ensure all tests run on push to main