### PR TITLE
Fix helm chart

### DIFF
--- a/charts/kms-issuer/Chart.yaml
+++ b/charts/kms-issuer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kms-issuer/templates/deployment.yaml
+++ b/charts/kms-issuer/templates/deployment.yaml
@@ -73,15 +73,15 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ include "kms-issuer.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
-    {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-    affinity:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
The deployment template was producing an invalid deployment when using a `nodeSelector`:

```bash
helm upgrade --install kms-issuer2 kms-issuer/kms-issuer --namespace kms-issuer-system --create-namespace --set 'nodeSelector.purpose=infra' Release "kms-issuer2" does not exist. Installing it now.
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template): unknown field "nodeSelector" in io.k8s.api.core.v1.PodTemplateSpec
```

The `nodeSelector`, `affinity` and `tolerations` keys were under `spec.template` instead of `spec.template.spec`.

With this fix it works:

```bash
pwd; helm upgrade --install kms-issuer . --namespace kms-issuer-system --create-namespace --set 'nodeSelector.purpose=infra,tolerations[0].effect=NoSchedule,tolerations[0].key=dedicated,tolerations[0].operator=Equal,tolerations[0].value=infra'
/home/fred/git/third_party/kms-issuer/charts/kms-issuer
Release "kms-issuer" does not exist. Installing it now.
NAME: kms-issuer
LAST DEPLOYED: Thu Jul 14 12:21:57 2022
NAMESPACE: kms-issuer-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
