### PR TITLE
Fix linting test failures

### DIFF
--- a/apis/certmanager/v1alpha1/groupversion_info.go
+++ b/apis/certmanager/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the cert-manager.skyscanner.net v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=cert-manager.skyscanner.net
+// +kubebuilder:object:generate=true
+// +groupName=cert-manager.skyscanner.net
 package v1alpha1
 
 import (


### PR DESCRIPTION
Fix linting failures in automated tests by updating the formatting for group_version_info.