### PR TITLE
Allow configuration of securityContext for PSA/PSS usage

### DIFF
--- a/charts/kms-issuer/Chart.yaml
+++ b/charts/kms-issuer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kms-issuer/templates/deployment.yaml
+++ b/charts/kms-issuer/templates/deployment.yaml
@@ -68,9 +68,9 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         securityContext:
-          allowPrivilegeEscalation: false
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
       securityContext:
-        runAsNonRoot: true
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "kms-issuer.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.nodeSelector }}

--- a/charts/kms-issuer/values.yaml
+++ b/charts/kms-issuer/values.yaml
@@ -51,6 +51,14 @@ certManagerApprovalRBAC:
   # -- The namespace where cert-manager service account is deployed
   namespace: cert-manager
 
+# Specifies pod Security Context
+podSecurityContext:
+  runAsNonRoot: true
+
+# Specifies Container Security Context
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+
 podAnnotations: {}
 
 resources: {}


### PR DESCRIPTION
For Migration to PSS/PSA you need to set certain settings in securityContext in pod or and container security Context. Therefore i added the option to set these via helmvalues. 

Reference: https://kubernetes.io/docs/concepts/security/pod-security-standards/