### PR TITLE
Fix golangci lint CI by pinning to v2.11.4

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.1.6
 
       - name: Build
         run: make build

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.11.4
 
       - name: Build
         run: make build

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,7 +26,7 @@ jobs:
           languages: go
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,9 +9,10 @@ formatters:
     - goimports
   settings:
     goimports:
-      local-prefixes: github.com/Skyscanner/kms-issuer
+      local-prefixes:
+        - github.com/Skyscanner/kms-issuer
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
@@ -58,12 +59,12 @@ linters:
     govet:
       enable:
         - shadow
-issues:
-  exclude-dirs:
-    - .git
-    - deploy
-    - config
-    - hack
-  exclude-rules:
-    - path: _test\.go
-      text: "dot-imports"
+  exclusions:
+    paths:
+      - .git
+      - deploy
+      - config
+      - hack
+    rules:
+      - path: _test\.go
+        text: "dot-imports"

--- a/controllers/certmanager/certificaterequest_controller.go
+++ b/controllers/certmanager/certificaterequest_controller.go
@@ -21,8 +21,6 @@ import (
 	"encoding/pem"
 	"fmt"
 
-	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
-	kmsca "github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -36,6 +34,9 @@ import (
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
+	kmsca "github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 )
 
 const (

--- a/controllers/certmanager/certificaterequest_controller.go
+++ b/controllers/certmanager/certificaterequest_controller.go
@@ -18,9 +18,8 @@ package certmanager
 
 import (
 	"context"
-	"fmt"
-
 	"encoding/pem"
+	"fmt"
 
 	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
 	kmsca "github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
@@ -69,7 +68,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Fetch the CertificateRequest resource being reconciled.
 	// Just ignore the request if the certificate request has been deleted.
 	cr := new(cmapi.CertificateRequest)
-	if err := r.Client.Get(ctx, req.NamespacedName, cr); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, cr); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
@@ -81,7 +80,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Check the CertificateRequest's issuerRef and if it does not match the api
 	// group name, log a message at a debug level and stop processing.
 	if cr.Spec.IssuerRef.Group != "" && cr.Spec.IssuerRef.Group != kmsiapi.GroupVersion.Group {
-		log.V(4).Info("resource does not specify an issuerRef group name that we are responsible for", "group", cr.Spec.IssuerRef.Group) //nolint:gomnd // TODO: fix when refactoring the logger
+		log.V(4).Info("resource does not specify an issuerRef group name that we are responsible for", "group", cr.Spec.IssuerRef.Group)
 		return ctrl.Result{}, nil
 	}
 
@@ -93,7 +92,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// If the certificate data is already set then we skip this request as it
 	// has already been completed in the past.
 	if len(cr.Status.Certificate) > 0 {
-		log.V(4).Info("existing certificate data found in status, skipping already completed CertificateRequest") //nolint:gomnd // TODO: fix when refactoring the logger
+		log.V(4).Info("existing certificate data found in status, skipping already completed CertificateRequest")
 		return ctrl.Result{}, nil
 	}
 
@@ -109,7 +108,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		Namespace: req.Namespace,
 		Name:      cr.Spec.IssuerRef.Name,
 	}
-	if err = r.Client.Get(ctx, issNamespaceName, &issuer); err != nil {
+	if err = r.Get(ctx, issNamespaceName, &issuer); err != nil {
 		log.Error(err, "failed to retrieve KMSIssuer resource", "namespace", req.Namespace, "name", cr.Spec.IssuerRef.Name)
 		_ = r.setStatus(ctx, cr, cmmeta.ConditionFalse, cmapi.CertificateRequestReasonPending, "Failed to retrieve KMSIssuer resource %s: %v", issNamespaceName, err)
 		return ctrl.Result{}, err

--- a/controllers/certmanager/certificaterequest_controller_test.go
+++ b/controllers/certmanager/certificaterequest_controller_test.go
@@ -29,11 +29,10 @@ import (
 	"time"
 
 	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
+	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-
-	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -98,7 +97,7 @@ var _ = Context("CertificateRequestReconciler", func() {
 				},
 				exampleDNSNames, exampleIPAddresses, exampleURIs,
 			)
-			cr.ObjectMeta.Namespace = crKey.Namespace
+			cr.Namespace = crKey.Namespace
 			cr.Spec.IssuerRef.Group = kmsiapi.GroupVersion.Group
 			Expect(err).To(BeNil())
 			Expect(k8sClient.Create(context.Background(), cr)).Should(Succeed(), "failed to create test CertificateRequest resource")

--- a/controllers/certmanager/certificaterequest_controller_test.go
+++ b/controllers/certmanager/certificaterequest_controller_test.go
@@ -28,8 +28,6 @@ import (
 	"testing"
 	"time"
 
-	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
-	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -44,6 +42,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
+	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 )
 
 var _ = Context("CertificateRequestReconciler", func() {

--- a/controllers/certmanager/kmsissuer_controller.go
+++ b/controllers/certmanager/kmsissuer_controller.go
@@ -25,8 +25,6 @@ import (
 	"fmt"
 	"time"
 
-	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
-	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 	"github.com/go-logr/logr"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +33,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
+	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 )
 
 const (

--- a/controllers/certmanager/kmsissuer_controller.go
+++ b/controllers/certmanager/kmsissuer_controller.go
@@ -76,7 +76,7 @@ func (r *KMSIssuerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// retrieve the KMSIssuer resource to reconcile.
 	issuer := &kmsiapi.KMSIssuer{}
-	if err := r.Client.Get(ctx, req.NamespacedName, issuer); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, issuer); err != nil {
 		log.Error(err, "failed to retrieve KMSIssuer resource")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}

--- a/controllers/certmanager/kmsissuer_controller.go
+++ b/controllers/certmanager/kmsissuer_controller.go
@@ -115,7 +115,7 @@ func (r *KMSIssuerReconciler) setIssuerDefaultValues(issuer *kmsiapi.KMSIssuer) 
 		log.Info("setting default duration", "duration", defaultCertDuration)
 		issuer.Spec.Duration = &metav1.Duration{Duration: defaultCertDuration}
 	}
-	renewBefore := time.Duration(float64(issuer.Spec.Duration.Duration.Nanoseconds()) * defaultCertRenewalRatio)
+	renewBefore := time.Duration(float64(issuer.Spec.Duration.Duration.Nanoseconds()) * defaultCertRenewalRatio) //nolint:staticcheck // QF1008: Duration is a named field on metav1.Duration, not an embedded type
 	if issuer.Spec.RenewBefore == nil {
 		log.Info("setting default", "RenewBefore", renewBefore)
 		issuer.Spec.RenewBefore = &metav1.Duration{
@@ -134,14 +134,14 @@ func (r *KMSIssuerReconciler) setIssuerDefaultValues(issuer *kmsiapi.KMSIssuer) 
 func (r *KMSIssuerReconciler) patchIssuerStatus(ctx context.Context, issuer *kmsiapi.KMSIssuer) error {
 	var latest kmsiapi.KMSIssuer
 
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(issuer), &latest); err != nil {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(issuer), &latest); err != nil {
 		return err
 	}
 
 	patch := client.MergeFrom(latest.DeepCopy())
 	latest.Status = issuer.Status
 
-	return r.Client.Status().Patch(ctx, &latest, patch)
+	return r.Status().Patch(ctx, &latest, patch)
 }
 
 // ParseCertificate parse the x509 certificate.

--- a/controllers/certmanager/kmsissuer_controller_test.go
+++ b/controllers/certmanager/kmsissuer_controller_test.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"time"
 
-	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
-
-	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
+	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
 )
 
 func WaitIssuerReady(key client.ObjectKey) *kmsiapi.KMSIssuer {

--- a/controllers/certmanager/kmskey_controller.go
+++ b/controllers/certmanager/kmskey_controller.go
@@ -62,7 +62,7 @@ func (r *KMSKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// retrieve the KMSKey resource to reconcile.
 	kmsKey := &kmsiapi.KMSKey{}
-	if err := r.Client.Get(ctx, req.NamespacedName, kmsKey); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, kmsKey); err != nil {
 		log.Error(err, "failed to retrieve KMSKey resource")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -127,14 +127,14 @@ func (r *KMSKeyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *KMSKeyReconciler) patchKeyStatus(ctx context.Context, issuer *kmsiapi.KMSKey) error {
 	var latest kmsiapi.KMSKey
 
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(issuer), &latest); err != nil {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(issuer), &latest); err != nil {
 		return err
 	}
 
 	patch := client.MergeFrom(latest.DeepCopy())
 	latest.Status = issuer.Status
 
-	return r.Client.Status().Patch(ctx, &latest, patch)
+	return r.Status().Patch(ctx, &latest, patch)
 }
 
 // manageSuccess

--- a/controllers/certmanager/kmskey_controller_test.go
+++ b/controllers/certmanager/kmskey_controller_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
@@ -28,6 +27,8 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kmsiapi "github.com/Skyscanner/kms-issuer/v4/apis/certmanager/v1alpha1"
 )
 
 func WaitForKMSKeyReady(key client.ObjectKey) *kmsiapi.KMSKey {

--- a/main.go
+++ b/main.go
@@ -99,12 +99,12 @@ func main() {
 	awsLoadConfigOpts := []func(*config.LoadOptions) error{}
 	if localAWSEndpoint != "" {
 		setupLog.Info("Using custom AWS Endpoint", "endpoint", localAWSEndpoint)
-		awsEndpointsResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-			return aws.Endpoint{PartitionID: "aws", URL: localAWSEndpoint, SigningRegion: "eu-west-1"}, nil
+		awsEndpointsResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) { //nolint:staticcheck // SA1019: deprecated but functional, migration to per-service resolver deferred
+			return aws.Endpoint{PartitionID: "aws", URL: localAWSEndpoint, SigningRegion: "eu-west-1"}, nil //nolint:staticcheck // SA1019: deprecated but functional, migration to per-service resolver deferred
 		})
 		awsLoadConfigOpts = append(
 			awsLoadConfigOpts,
-			config.WithEndpointResolverWithOptions(awsEndpointsResolver),
+			config.WithEndpointResolverWithOptions(awsEndpointsResolver), //nolint:staticcheck // SA1019: deprecated but functional, migration to per-service resolver deferred
 			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "test")),
 			config.WithRegion("eu-west-1"),
 		)

--- a/pkg/kmsca/kmsca.go
+++ b/pkg/kmsca/kmsca.go
@@ -83,13 +83,13 @@ func (ca *KMSCA) CreateKey(ctx context.Context, input *CreateKeyInput) (string, 
 		KeyUsage: kmstypes.KeyUsageTypeSignVerify,
 		KeySpec:  kmstypes.KeySpec(kmstypes.CustomerMasterKeySpecRsa2048),
 	}
-	if len(input.CustomerMasterKeySpec) > 0 {
+	if input.CustomerMasterKeySpec != "" {
 		keyInput.KeySpec = kmstypes.KeySpec(input.CustomerMasterKeySpec)
 	}
-	if len(input.Description) > 0 {
+	if input.Description != "" {
 		keyInput.Description = aws.String(input.Description)
 	}
-	if len(input.Policy) > 0 {
+	if input.Policy != "" {
 		keyInput.Policy = aws.String(input.Policy)
 	}
 	if len(input.Tags) > 0 {
@@ -126,7 +126,7 @@ func (ca *KMSCA) DeleteKey(ctx context.Context, input *DeleteKeyInput) error {
 		KeyId: response.KeyMetadata.KeyId,
 	}
 	if input.PendingWindowInDays > 0 {
-		deleteInput.PendingWindowInDays = aws.Int32(int32(input.PendingWindowInDays))
+		deleteInput.PendingWindowInDays = aws.Int32(int32(input.PendingWindowInDays)) //nolint:gosec // G115: value is bounded to 7-30 by CRD validation
 	}
 
 	_, err = ca.Client.ScheduleKeyDeletion(ctx, deleteInput)

--- a/pkg/kmsca/kmsca.go
+++ b/pkg/kmsca/kmsca.go
@@ -29,11 +29,12 @@ import (
 	"crypto/sha1" //nolint:gosec // Used for consistent hash
 	"math/big"
 
-	"github.com/Skyscanner/kms-issuer/v4/pkg/interfaces"
-	"github.com/Skyscanner/kms-issuer/v4/pkg/signer"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+
+	"github.com/Skyscanner/kms-issuer/v4/pkg/interfaces"
+	"github.com/Skyscanner/kms-issuer/v4/pkg/signer"
 )
 
 const (

--- a/pkg/kmsca/kmsca_test.go
+++ b/pkg/kmsca/kmsca_test.go
@@ -26,13 +26,14 @@ import (
 	"net"
 	"time"
 
-	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
-	mocks "github.com/Skyscanner/kms-issuer/v4/pkg/kmsmock"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/Skyscanner/kms-issuer/v4/pkg/kmsca"
+	mocks "github.com/Skyscanner/kms-issuer/v4/pkg/kmsmock"
 )
 
 var _ = Context("KMSCA", func() {

--- a/pkg/kmsmock/kmsmock.go
+++ b/pkg/kmsmock/kmsmock.go
@@ -25,11 +25,12 @@ import (
 	"encoding/pem"
 	"strings"
 
-	"github.com/Skyscanner/kms-issuer/v4/pkg/interfaces"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/google/uuid"
+
+	"github.com/Skyscanner/kms-issuer/v4/pkg/interfaces"
 )
 
 var (

--- a/pkg/kmsmock/kmsmock_test.go
+++ b/pkg/kmsmock/kmsmock_test.go
@@ -20,16 +20,16 @@ import (
 	"context"
 	"crypto"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 
-	"crypto/sha256"
-
-	mocks "github.com/Skyscanner/kms-issuer/v4/pkg/kmsmock"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	mocks "github.com/Skyscanner/kms-issuer/v4/pkg/kmsmock"
 )
 
 var _ = Context("KMSMock", func() {

--- a/pkg/signer/kmssigner.go
+++ b/pkg/signer/kmssigner.go
@@ -22,9 +22,10 @@ import (
 	"crypto/x509"
 	"io"
 
-	"github.com/Skyscanner/kms-issuer/v4/pkg/interfaces"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+
+	"github.com/Skyscanner/kms-issuer/v4/pkg/interfaces"
 )
 
 // KMSSigner implements the crypto/Signer interface that can be used for signing operations

--- a/pkg/signer/kmssigner_test.go
+++ b/pkg/signer/kmssigner_test.go
@@ -21,16 +21,15 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-
-	mocks "github.com/Skyscanner/kms-issuer/v4/pkg/kmsmock"
-	"github.com/Skyscanner/kms-issuer/v4/pkg/signer"
-	"github.com/aws/aws-sdk-go-v2/service/kms"
-
 	"math/big"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	mocks "github.com/Skyscanner/kms-issuer/v4/pkg/kmsmock"
+	"github.com/Skyscanner/kms-issuer/v4/pkg/signer"
 )
 
 var _ = Context("Signer", func() {


### PR DESCRIPTION
Fixing https://github.com/Skyscanner/kms-issuer/actions/runs/24346973339/job/71090443059#step:5:65

version: latest resolves to golangci-lint v1.64.8 (built with Go 1.24), which can't analyze Go 1.25 code, pin to v2.11.4 to match the Go version in go.mod.