### PR TITLE
Fix release workflow and update helm workflow actions

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -13,40 +13,36 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMG: skyscanner/kms-issuer:dev
-      CERT_MANAGER_VERSION: v1.8.0
+      CERT_MANAGER_VERSION: v1.17.2
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version-file: go.mod
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3.5
-        with:
-          version: v3.5.2
+        uses: Azure/setup-helm@v4
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
-      - uses: actions/setup-python@v4.5.0
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
-        with:
-          version: v3.6.0
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
@@ -54,7 +50,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.12.0
         with:
           cluster_name: kind
         if: steps.list-changed.outputs.changed == 'true'
@@ -79,7 +75,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install helm-docs
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
 
       - name: Run helm-docs
-        uses: docker://jnorwood/helm-docs:v1.10.0
+        run: |
+          helm-docs
+          git diff --exit-code || (echo "Helm docs are out of date. Run 'helm-docs' and commit." && exit 1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,13 @@ jobs:
 
           git fetch origin gh-pages:gh-pages 2>/dev/null || true
           git stash --include-untracked
-          git checkout gh-pages 2>/dev/null || git checkout --orphan gh-pages
+
+          if git checkout gh-pages 2>/dev/null; then
+            echo "Checked out existing gh-pages branch"
+          else
+            git checkout --orphan gh-pages
+            git rm -rf .
+          fi
 
           # Copy packaged chart and rebuild index
           cp /tmp/helm-pkg/*.tgz .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,42 +6,70 @@ on:
       - published
 
 jobs:
-  release:
+  docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - uses: actions/checkout@v3.1.0
-
-      - name: Publish Helm charts
-        uses: stefanprodan/helm-gh-pages@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          # list of Docker images to use as base name for tags
           images: |
             ghcr.io/skyscanner/kms-issuer
-          # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{raw}}
 
       - name: Login to GitHub Packages
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish a docker image
-        uses: docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  helm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Helm
+        uses: Azure/setup-helm@v4
+
+      - name: Package Helm chart
+        run: |
+          helm package charts/kms-issuer -d /tmp/helm-pkg
+
+      - name: Publish Helm chart to gh-pages
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+          git fetch origin gh-pages:gh-pages 2>/dev/null || true
+          git stash --include-untracked
+          git checkout gh-pages 2>/dev/null || git checkout --orphan gh-pages
+
+          # Copy packaged chart and rebuild index
+          cp /tmp/helm-pkg/*.tgz .
+          helm repo index . --url https://skyscanner.github.io/kms-issuer/
+
+          git add .
+          git commit -m "Publish Helm chart for ${{ github.event.release.tag_name }}" || true
+          git push origin gh-pages


### PR DESCRIPTION
- Replace disallowed stefanprodan/helm-gh-pages action with inline steps using Azure/setup-helm. 
- Split release into independent docker and helm jobs so Docker image publishes even if Helm fails. 
- Replace disallowed docker://jnorwood/helm-docs with go install. 
- Bump all actions and dependencies to latest versions