### PR TITLE
Migrate Helm chart publishing from gh pages to OCI registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
   helm:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -53,29 +54,10 @@ jobs:
       - name: Setup Helm
         uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
-      - name: Package Helm chart
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+      - name: Package and push Helm chart
         run: |
-          helm package charts/kms-issuer -d /tmp/helm-pkg
-
-      - name: Publish Helm chart to gh-pages
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-          git fetch origin gh-pages:gh-pages 2>/dev/null || true
-          git stash --include-untracked
-
-          if git checkout gh-pages 2>/dev/null; then
-            echo "Checked out existing gh-pages branch"
-          else
-            git checkout --orphan gh-pages
-            git rm -rf .
-          fi
-
-          # Copy packaged chart and rebuild index
-          cp /tmp/helm-pkg/*.tgz .
-          helm repo index . --url https://skyscanner.github.io/kms-issuer/
-
-          git add .
-          git commit -m "Publish Helm chart for ${{ github.event.release.tag_name }}" || true
-          git push origin gh-pages
+          helm package charts/kms-issuer
+          helm push kms-issuer-*.tgz oci://ghcr.io/skyscanner/charts

--- a/README.md
+++ b/README.md
@@ -15,17 +15,16 @@ For any details on Cert-Manager, check the [official documentation](https://cert
 
 ## Install
 
-You can install the controller using the official helm chart:
+You can install the controller using the official Helm chart from the OCI registry:
 
 ```console
-helm repo add kms-issuer 'https://skyscanner.github.io/kms-issuer'
-helm repo update
+helm upgrade --install kms-issuer oci://ghcr.io/skyscanner/charts/kms-issuer --namespace kms-issuer-system --create-namespace
 ```
 
-To install the chart with the release name `kms-issuer`:
+To install a specific version:
 
 ```console
-helm upgrade --install kms-issuer kms-issuer/kms-issuer --namespace kms-issuer-system --create-namespace
+helm upgrade --install kms-issuer oci://ghcr.io/skyscanner/charts/kms-issuer --version <version> --namespace kms-issuer-system --create-namespace
 ```
 
 ### Usage


### PR DESCRIPTION
Summary                                                                                                                                                      
                  
  - Replaces the gh-pages-based Helm chart publishing with OCI push to ghcr.io/skyscanner/charts                                                                                                                                                             
  - Updates README install instructions to use the OCI registry URL